### PR TITLE
BIN-1205: Support for HS USB and GUI

### DIFF
--- a/hw/bsp/lpc55/boards/lpcxpresso55s16/board.h
+++ b/hw/bsp/lpc55/boards/lpcxpresso55s16/board.h
@@ -57,7 +57,7 @@
 //--------------------------------------------------------------------+
 
  // Number of neopixels
-#define NEOPIXEL_NUMBER       1
+#define NEOPIXEL_NUMBER       0
 #define NEOPIXEL_PORT         1
 #define NEOPIXEL_PIN          8
 #define NEOPIXEL_IOMUX        IOCON_PIO_DIG_FUNC4_EN
@@ -65,7 +65,7 @@
 #define NEOPIXEL_TYPE         0
 
 // Brightness percentage from 1 to 255
-#define NEOPIXEL_BRIGHTNESS   0X50
+#define NEOPIXEL_BRIGHTNESS   0XF0
 
 #ifdef __cplusplus
  }

--- a/hw/bsp/lpc55/family.c
+++ b/hw/bsp/lpc55/family.c
@@ -160,13 +160,17 @@ void board_init(void)
 
   // Init 150 MHz clock from PLL0 and internal FRO12M oscillator.
   BootClockPLL150MFromFRO12M();
-
-  // 1ms tick timer
+#if CFG_TUSB_OS == OPT_OS_NONE
+// 1ms tick timer
   SysTick_Config(SystemCoreClock / 1000);
 
-#if CFG_TUSB_OS == OPT_OS_FREERTOS
+#elif CFG_TUSB_OS == OPT_OS_FREERTOS
+#if PORT_SUPPORT_DEVICE(0)
   // If freeRTOS is used, IRQ priority is limit by max syscall ( smaller is higher )
   NVIC_SetPriority(USB0_IRQn, configLIBRARY_MAX_SYSCALL_INTERRUPT_PRIORITY );
+#elif PORT_SUPPORT_DEVICE(1)
+  NVIC_SetPriority(USB1_IRQn, configLIBRARY_MAX_SYSCALL_INTERRUPT_PRIORITY );
+#endif
 #endif
 
   // Init all GPIO ports

--- a/tools/get_deps.py
+++ b/tools/get_deps.py
@@ -182,7 +182,7 @@ deps_optional = {
                          'e73e04ca63495672d955f9268e003cffe168fcd8',
                          'lpc55'],
     'lib/sct_neopixel-binho': ['https://github.com/binhollc/sct_neopixel-binho.git',
-                         '715a6b6c489200b9b5fec95460a36f2c0a4dfc04',
+                         '0a1c48eafe208dd015e561bcf526022fc57d0863',
                          'lpc55'],
 }
 


### PR DESCRIPTION
# Resolves
[BIN-1205](https://focusuy.atlassian.net/browse/BIN-1205)

# Changes
This PR updates configuration files for the Binho Pulsar to support the HS USB and GUI. With this firmware version, the Binho Pulsar will light on on connection and must appear as an HID device.

An updated version of binho-neopixel is needed to support the GUI for the pulsar. 