### PR TITLE
BIN-1210 | Update USB endpoint size for Pulsar

### DIFF
--- a/src/class/hid/hid_device.h
+++ b/src/class/hid/hid_device.h
@@ -391,14 +391,14 @@ static inline bool  tud_hid_gamepad_report(uint8_t report_id, int8_t x, int8_t y
       HID_LOGICAL_MIN ( 0x00                                   ),\
       HID_LOGICAL_MAX_N ( 0xff, 2                              ),\
       HID_REPORT_SIZE ( 8                                      ),\
-      HID_REPORT_COUNT( report_size                            ),\
+	    HID_REPORT_COUNT_N ( report_size, 2                      ),\
       HID_INPUT       ( HID_DATA | HID_VARIABLE | HID_ABSOLUTE ),\
       /* Output */ \
       HID_USAGE       ( 0x03                                    ),\
       HID_LOGICAL_MIN ( 0x00                                    ),\
       HID_LOGICAL_MAX_N ( 0xff, 2                               ),\
       HID_REPORT_SIZE ( 8                                       ),\
-      HID_REPORT_COUNT( report_size                             ),\
+	    HID_REPORT_COUNT_N ( report_size, 2                       ),\
       HID_OUTPUT      ( HID_DATA | HID_VARIABLE | HID_ABSOLUTE  ),\
     HID_COLLECTION_END \
 


### PR DESCRIPTION
## Resolve:
[BIN-1210](https://focusuy.atlassian.net/browse/BIN-1210)

## Changes:

- Enables a 2-byte USB endpoint size. All the changes needed to support this are already included in the tiny-USB package; the only changes needed were to update the HID device configuration to use the n-byte version of the byte length counter. 
