### PR TITLE
BIN-1181 | Spike: Test new-tinyusb library running on MCXN947 MCU

### DIFF
--- a/hw/bsp/mcx/boards/frdm_mcxn947/board.h
+++ b/hw/bsp/mcx/boards/frdm_mcxn947/board.h
@@ -32,18 +32,21 @@
 #endif
 
 // LED
+#define LED_ENABLED           0
 #define LED_GPIO              GPIO0
 #define LED_CLK               kCLOCK_Gpio0
 #define LED_PIN               10 // red
 #define LED_STATE_ON          0
 
 // WAKE button (Dummy, use unused pin
+#define BUTTON_ENABLED        0
 #define BUTTON_GPIO           GPIO0
 #define BUTTON_CLK            kCLOCK_Gpio0
 #define BUTTON_PIN            23
 #define BUTTON_STATE_ACTIVE   0
 
 // UART
+#define UART_ENABLED          0
 #define UART_DEV              LPUART4
 
 static inline void board_uart_init_clock(void) {

--- a/hw/bsp/mcx/family.c
+++ b/hw/bsp/mcx/family.c
@@ -74,10 +74,12 @@ void board_init(void) {
 #endif
 
   // LED
+#if LED_ENABLED
   CLOCK_EnableClock(LED_CLK);
   gpio_pin_config_t led_config = {kGPIO_DigitalOutput, 0};
   GPIO_PinInit(LED_GPIO, LED_PIN, &led_config);
   board_led_write(0);
+#endif
 
 #ifdef NEOPIXEL_PIN
   // Neopixel
@@ -92,12 +94,15 @@ void board_init(void) {
 #endif
 
   // Button
+#if BUTTON_ENABLED
 #ifdef BUTTON_GPIO
   CLOCK_EnableClock(BUTTON_CLK);
   gpio_pin_config_t const button_config = {kGPIO_DigitalInput, 0};
   GPIO_PinInit(BUTTON_GPIO, BUTTON_PIN, &button_config);
 #endif
+#endif
 
+#if UART_ENABLED
 #ifdef UART_DEV
   // UART
 //  IOCON_PinMuxSet(IOCON, UART_RX_PINMUX);
@@ -112,6 +117,7 @@ void board_init(void) {
   uart_config.enableTx = true;
   uart_config.enableRx = true;
   LPUART_Init(UART_DEV, &uart_config, 12000000u);
+#endif
 #endif
 
   // USB VBUS

--- a/hw/bsp/mcx/family.mk
+++ b/hw/bsp/mcx/family.mk
@@ -35,13 +35,13 @@ SRC_C += \
 	$(SDK_DIR)/devices/$(MCU_VARIANT)/system_$(MCU_CORE).c \
 	$(SDK_DIR)/devices/$(MCU_VARIANT)/drivers/fsl_clock.c \
 	$(SDK_DIR)/devices/$(MCU_VARIANT)/drivers/fsl_reset.c \
-	$(SDK_DIR)/devices/$(MCU_VARIANT)/drivers/fsl_gpio.c \
-	$(SDK_DIR)/devices/$(MCU_VARIANT)/drivers/fsl_lpuart.c \
-	$(SDK_DIR)/devices/$(MCU_VARIANT)/drivers/fsl_common_arm.c \
+	$(SDK_DIR)/drivers/gpio/fsl_gpio.c \
+	$(SDK_DIR)/drivers/lpuart/fsl_lpuart.c \
+	$(SDK_DIR)/drivers/common/fsl_common_arm.c \
 
 # fsl_lpflexcomm for MCXN9
 ifeq ($(MCU_VARIANT), MCXN947)
-	SRC_C += $(SDK_DIR)/devices/$(MCU_VARIANT)/drivers/fsl_lpflexcomm.c
+	SRC_C += $(SDK_DIR)/drivers/lpflexcomm/fsl_lpflexcomm.c
 endif
 
 # fsl_spc for MCXNA15
@@ -54,5 +54,12 @@ INC += \
 	$(TOP)/lib/CMSIS_5/CMSIS/Core/Include \
 	$(TOP)/$(SDK_DIR)/devices/$(MCU_VARIANT) \
 	$(TOP)/$(SDK_DIR)/devices/$(MCU_VARIANT)/drivers \
+
+INC += \
+	$(TOP)/$(SDK_DIR)/drivers/common \
+	$(TOP)/$(SDK_DIR)/drivers/gpio \
+	$(TOP)/$(SDK_DIR)/drivers/lpuart \
+	$(TOP)/$(SDK_DIR)/drivers/port \
+	$(TOP)/$(SDK_DIR)/drivers/lpflexcomm \
 
 SRC_S += $(SDK_DIR)/devices/$(MCU_VARIANT)/gcc/startup_$(MCU_CORE).S

--- a/tools/get_deps.py
+++ b/tools/get_deps.py
@@ -56,7 +56,7 @@ deps_optional = {
                            'b41cf930e65c734d8ec6de04f1d57d46787c76ae',
                            'lpc11 lpc13 lpc15 lpc17 lpc18 lpc40 lpc43'],
     'hw/mcu/nxp/mcux-sdk': ['https://github.com/nxp-mcuxpresso/mcux-sdk.git',
-                           'f6c93eeb2372410019006fbf16a667ed79e44d86',
+                           '0420001d787c2c7bb062a2da4c46233d9daf2737',
                            'kinetis_k kinetis_k32l2 kinetis_kl lpc51 lpc54 lpc55 mcx imxrt'],
     'hw/mcu/raspberry_pi/Pico-PIO-USB': ['https://github.com/sekigon-gonnoc/Pico-PIO-USB.git',
                                          'fe9133fc513b82cc3dc62c67cb51f2339cf29ef7',


### PR DESCRIPTION
# Resolves
[BIN-1181](https://focusuy.atlassian.net/browse/BIN-1181)

# Changes
This PR updates the NXP mcux-sdk dependency to clone the repo in the commit that gives support for MCX boards. It also modifies the pertinent files to build the `hid_generic_inout` example correctly. After testing, everything works as expected; the USB communication with the FRDM-MCXN947 eval kit is functioning correctly.