### PR TITLE
BIN-1533: Update sct_neopixel-binho dependency

### DIFF
--- a/hw/bsp/lpc55/family.mk
+++ b/hw/bsp/lpc55/family.mk
@@ -50,7 +50,7 @@ SRC_C += \
 
 INC += \
 	$(TOP)/$(BOARD_PATH) \
-	$(TOP)/lib/sct_neopixel \
+	$(TOP)/lib/sct_neopixel-binho \
 	$(TOP)/lib/CMSIS_5/CMSIS/Core/Include \
 	$(TOP)/$(MCU_DIR) \
 	$(TOP)/$(MCU_DIR)/drivers \

--- a/tools/get_deps.py
+++ b/tools/get_deps.py
@@ -204,11 +204,8 @@ deps_optional = {
     'lib/CMSIS_6': ['https://github.com/ARM-software/CMSIS_6.git',
                     'b0bbb0423b278ca632cfe1474eb227961d835fd2',
                     'ra'],
-    'lib/sct_neopixel': ['https://github.com/gsteiert/sct_neopixel.git',
-                         'e73e04ca63495672d955f9268e003cffe168fcd8',
-                         'lpc55'],
     'lib/sct_neopixel-binho': ['https://github.com/binhollc/sct_neopixel-binho.git',
-                         '0a1c48eafe208dd015e561bcf526022fc57d0863',
+                         '2bb2bae5614fe0fdfc94711d909a4dc44d098d4b',
                          'lpc55'],
 }
 


### PR DESCRIPTION
### Resolves:

[BIN-1533](https://focusuy.atlassian.net/browse/BIN-1533)

### Changes:

Update sct_neopixel-binho dependency.
Remove original sct_neopixel library dependency
